### PR TITLE
Point ARCHITECTURE.md at docs/

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,11 @@ This repository contains educational documentation about cloud computing,
 virtualization, and distributed systems. The content is written for
 shakenfist.com and is synced into the main Shaken Fist documentation site.
 
+The documentation itself is the product: [docs/index.md](docs/index.md)
+is the introduction and navigation, and [docs/order.yml](docs/order.yml)
+controls which pages are imported and in what order. This document
+describes only how the repository is built and published.
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
`ARCHITECTURE.md` never referenced a page under `docs/`, even though in this repository the documentation *is* the product — `docs/index.md` is the introduction and navigation, and `docs/order.yml` controls which pages are imported and in what order.

This adds a short paragraph naming both, and saying that `ARCHITECTURE.md` describes only how the repository is built and published.

The file is already comfortably summary-sized (103 lines), so nothing moves.

Resolves the new `llm-doc-structure` consistency audit for this repository. `pre-commit run --all-files` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)